### PR TITLE
Remove all instances of console.log

### DIFF
--- a/sofa/SOFA.js
+++ b/sofa/SOFA.js
@@ -42,8 +42,7 @@ class SOFA  {
     let name = match[1];
     let content = JSON.parse(match[2]);
     if (!this[name]) {
-      console.log(name + ' is not a valid SOFA type');
-      return null;
+      throw new Error(name + ' is not a valid SOFA type');
     }
     return this[name](content);
   }

--- a/sofa/SOFAObject.js
+++ b/sofa/SOFAObject.js
@@ -10,10 +10,13 @@ class SOFAObject {
       if (!this.hasOwnProperty(k)) { this[k] = v; }
     }
 
-    let ajv = new Ajv();
-    this.validate = ajv.compile(schema);
-    var valid = this.validate(content);
-    if (!valid) console.log(ajv.errorsText());
+    let ajv = new Ajv({allErrors: true});
+    let validate = ajv.compile(schema);
+    this._valid = validate(content);
+    if (!this._valid) {
+      // map error messages to errors property
+      this._errors = validate.errors.map((e) => e.message);
+    }
   }
 
   preprocess(content) {
@@ -38,6 +41,14 @@ class SOFAObject {
 
   get display() {
     return this.string;
+  }
+
+  get isValid() {
+    return this._valid;
+  }
+
+  get validationErrors() {
+    return this._errors;
   }
 }
 


### PR DESCRIPTION
main purpose is to get rid of this "No errors" message in the bots:
![image](https://user-images.githubusercontent.com/1412/27906612-928d59c4-6244-11e7-8e5c-efde09652515.png)
(this error is caused by the clients not including a `status` when they send their payment message via signal)
`ajv.errorsText()` also doesn't pick this up, the errors have to come from the validator.